### PR TITLE
configure: fix configure with modern clang

### DIFF
--- a/configure
+++ b/configure
@@ -148,7 +148,7 @@ else
 fi
 
 echo -n "Checking $(basename "${CC}") can produce executables ... "
-echo -e '#include <stdlib.h>\nmain() {exit(0);}' | \
+echo -e '#include <stdlib.h>\nint main(void) {exit(0);}' | \
 	if ${CC} -xc -o /dev/null - 2>>config.log; then
 		echo "Ok"
 	else


### PR DESCRIPTION
Fix for modern clang versions that are more pedantic.
```
Checking for a C compiler ... /usr/lib/ccache/bin/clang Checking clang can produce executables ... Fail
n>:2:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    2 | main() {exit(0);}
      | ^
      | int
1 error generated.
```